### PR TITLE
Update help-path.jelly

### DIFF
--- a/src/main/webapp/KPPNodeProperty/help-path.jelly
+++ b/src/main/webapp/KPPNodeProperty/help-path.jelly
@@ -26,5 +26,5 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:i="jelly:fmt">
     Only if iOS or OSX projects are to be built on this node, than type in the directory path where provisioning profiles are stored. (Optional)<br/>
-    e.g. "/User/{USERNAME}/Library/MobileDevice/Provisioning Profiles"
+    e.g. "/Users/{USERNAME}/Library/MobileDevice/Provisioning Profiles"
 </j:jelly>


### PR DESCRIPTION
Fix typo in help string. User home dirs are under /Users/, not /User/.
